### PR TITLE
Fix composer autoload

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,9 +28,7 @@
     
     "autoload": {
         "psr-4": {
-            "Export\\": "src/"
-        },
-        "psr-4": {
+            "Export\\": "src/",
             "ExportTest\\": "test/src/"
         }
     }


### PR DESCRIPTION
If composer json file contains two equivalent keys, than only second will be used, so autoloading for main classes will not work.
